### PR TITLE
Budget Alignment DAC Code Test

### DIFF
--- a/test_definitions/finance/13_budget_alignment.feature
+++ b/test_definitions/finance/13_budget_alignment.feature
@@ -16,5 +16,5 @@ Feature: Budget Alignment
      And `default-aid-type/@code` is not any of A01, A02 or G01
      And `transaction/aid-type/@code` is not any of A01 or A02
      Then `sector/@code` should be present
-     Then every `sector[@vocabulary="DAC" or not(@vocabulary) or @vocabulary="1"]/@code | transaction/sector[@vocabulary="1" or not(@vocabulary)]/@code` should be on the Sector codelist
+     And at least one `sector[@vocabulary="DAC" or not(@vocabulary) or @vocabulary="1"]/@code | transaction/sector[@vocabulary="1" or not(@vocabulary)]/@code` should be on the Sector codelist
      And `sector/@code` is not any of 43010, 43050, 43081, 43082, 52010, 99810, 11230, 11320, 15110, 15111, 15112, 15114, 15130, 16010, 16061, 21010, 21020, 22010, 23110, 43030 or 43040

--- a/test_definitions/finance/13_budget_alignment.feature
+++ b/test_definitions/finance/13_budget_alignment.feature
@@ -16,5 +16,5 @@ Feature: Budget Alignment
      And `default-aid-type/@code` is not any of A01, A02 or G01
      And `transaction/aid-type/@code` is not any of A01 or A02
      Then `sector/@code` should be present
-     And at least one `sector[@vocabulary="DAC" or not(@vocabulary) or @vocabulary="1"]/@code | transaction/sector[@vocabulary="1" or not(@vocabulary)]/@code` should be on the Sector codelist
+     And at least one `sector[not(@vocabulary) or @vocabulary="1"]/@code | transaction/sector[@vocabulary="1" or not(@vocabulary)]/@code` should be on the Sector codelist
      And `sector/@code` is not any of 43010, 43050, 43081, 43082, 52010, 99810, 11230, 11320, 15110, 15111, 15112, 15114, 15130, 16010, 16061, 21010, 21020, 22010, 23110, 43030 or 43040

--- a/test_definitions/finance/13_budget_alignment.feature
+++ b/test_definitions/finance/13_budget_alignment.feature
@@ -16,4 +16,5 @@ Feature: Budget Alignment
      And `default-aid-type/@code` is not any of A01, A02 or G01
      And `transaction/aid-type/@code` is not any of A01 or A02
      Then `sector/@code` should be present
+     Then every `sector[@vocabulary="DAC" or not(@vocabulary) or @vocabulary="1"]/@code | transaction/sector[@vocabulary="1" or not(@vocabulary)]/@code` should be on the Sector codelist
      And `sector/@code` is not any of 43010, 43050, 43081, 43082, 52010, 99810, 11230, 11320, 15110, 15111, 15112, 15114, 15130, 16010, 16061, 21010, 21020, 22010, 23110, 43030 or 43040

--- a/test_definitions/project_attributes/20_sector.feature
+++ b/test_definitions/project_attributes/20_sector.feature
@@ -9,4 +9,4 @@ Feature: Sector
   Scenario Outline: Sector uses DAC CRS 5 digit purpose codes
     Given an IATI activity
      And the activity is current
-     Then every `sector[@vocabulary="DAC" or not(@vocabulary) or @vocabulary="1"]/@code | transaction/sector[@vocabulary="1" or not(@vocabulary)]/@code` should be on the Sector codelist
+     Then every `sector[not(@vocabulary) or @vocabulary="1"]/@code | transaction/sector[@vocabulary="1" or not(@vocabulary)]/@code` should be on the Sector codelist


### PR DESCRIPTION
At present the Budget Alignment test only checks for invalid DAC codes, but does not check that the sector codes are valid according to the DAC codelist (http://reference.iatistandard.org/203/codelists/Sector/)

This work adds a check that sector codes are on the relevant codelist.

Related to: #14